### PR TITLE
Restructure into a Neovim plugin via LazyVim

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ require('ts-worksheet').setup({
 })
 ```
 
+### Using [Lazy.nvim](https://github.com/folke/lazy.nvim)
+
+Add the following to your Neovim configuration:
+
+```lua
+    {
+        "typed-rocks/ts-worksheet-neovim",
+        opts = {
+            severity = vim.diagnostic.severity.WARN,
+        },
+        config = function(_, opts)
+            require("tsw").setup(opts)
+        end
+    },
+
+```
+
 ## How To Use Other Runtimes
 
 Just make sure to have `bun` or `deno` available in your systems `PATH`.
@@ -45,3 +62,4 @@ By default it uses `node` as runtime and does not show the results of variables.
 ### Defaults:
 
 `Tsw rt=node show_variables=false show_order=false`
+

--- a/doc/tsw.txt
+++ b/doc/tsw.txt
@@ -1,0 +1,63 @@
+*tsw.txt*	For Neovim version 0.7 or later	Last change: 2024
+
+TSW - TYPESCRIPT WORKSHEET                                              *tsw*
+
+1. Introduction                      |tsw-introduction|
+2. Installation                      |tsw-installation|
+3. Configuration                     |tsw-configuration|
+4. Usage                             |tsw-usage|
+5. Commands                          |tsw-commands|
+
+==============================================================================
+1. Introduction                                                *tsw-introduction*
+
+Tsw (TypeScript Worksheet) is a Neovim plugin that provides live results for
+TypeScript and JavaScript code directly in your editor.
+
+==============================================================================
+2. Installation                                                *tsw-installation*
+
+Using Lazy.nvim:
+>
+    {
+      "yourusername/ts-worksheet-neovim",
+      config = function()
+        require("tsw").setup({
+          -- your configuration here
+        })
+      end
+    }
+<
+==============================================================================
+3. Configuration                                              *tsw-configuration*
+
+You can configure Tsw by passing a table to the setup function:
+>
+    require("tsw").setup({
+      severity = vim.diagnostic.severity.INFO
+    })
+<
+Options:
+    • severity: The severity level for diagnostics. Default is INFO.
+
+==============================================================================
+4. Usage                                                            *tsw-usage*
+
+To use Tsw in a TypeScript or JavaScript file:
+
+1. Add `//ts-worksheet` at the beginning of your file to automatically run Tsw
+   on save.
+2. Use the `:Tsw` command with optional parameters.
+
+==============================================================================
+5. Commands                                                        *tsw-commands*
+
+:Tsw [options]                                                            *:Tsw*
+    Run Tsw on the current buffer.
+    Options:
+        rt=[bun|node|deno]            Set the runtime
+        show_variables=[true|false]   Show variable values
+        show_order=[true|false]       Show execution order
+
+ vim:tw=78:ts=8:ft=help:norl:
+

--- a/lua/tsw/commands.lua
+++ b/lua/tsw/commands.lua
@@ -1,0 +1,42 @@
+local M = {}
+local utils = require('tsw.utils')
+local config = require('tsw.config')
+
+function M.setup()
+    vim.api.nvim_create_user_command("Tsw", function(opts)
+        local args = {}
+        for _, arg in pairs(vim.split(opts.args, "%s+")) do
+            local key, value = unpack(vim.split(arg, "="))
+            args[key] = value
+        end
+
+        local rt = "node"
+        local show_variables = args["show_variables"] == "true"
+        local show_order = args["show_order"] == "true"
+        if args["rt"] then
+            rt = args["rt"]
+        end
+
+        utils.add_inlay_hints(rt, show_variables, show_order)
+    end, { nargs = "*" })
+
+    vim.api.nvim_create_autocmd("BufWritePost", {
+        pattern = { "*.ts", "*.js" },
+        callback = function()
+            local bufnr = vim.api.nvim_get_current_buf()
+            vim.diagnostic.reset(config.namespace, bufnr)
+
+            -- Get the first line of the buffer
+            local first_line = vim.api.nvim_buf_get_lines(bufnr, 0, 1, false)[1]
+            -- Check if the first line starts with "//ts-worksheet"
+            if first_line and first_line:match("^//ts%-worksheet%-with%-variables") then
+                utils.add_inlay_hints("node", true, false)
+            elseif first_line and first_line:match("^//ts%-worksheet") then
+                utils.add_inlay_hints("node", false, false)
+            end
+        end,
+    })
+end
+
+return M
+

--- a/lua/tsw/config.lua
+++ b/lua/tsw/config.lua
@@ -1,0 +1,11 @@
+local M = {}
+
+M.severity = vim.diagnostic.severity.INFO
+M.namespace = vim.api.nvim_create_namespace("tsw")
+
+function M.setup(opts)
+    M.severity = opts.severity or M.severity
+end
+
+return M
+

--- a/lua/tsw/init.lua
+++ b/lua/tsw/init.lua
@@ -1,0 +1,12 @@
+local M = {}
+
+local config = require('tsw.config')
+local commands = require('tsw.commands')
+
+function M.setup(opts)
+    config.setup(opts)
+    commands.setup()
+end
+
+return M
+

--- a/lua/tsw/utils.lua
+++ b/lua/tsw/utils.lua
@@ -1,0 +1,211 @@
+local M = {}
+local config = require('tsw.config')
+
+local separator = package.config:sub(1, 1) -- Get the OS-specific directory separator
+
+function M.get_current_file_path()
+    return vim.api.nvim_buf_get_name(0)
+end
+
+function M.get_directory_from_path(file_path)
+    return vim.fn.fnamemodify(file_path, ":h")
+end
+
+local function read_file_to_string(filepath)
+    local file = io.open(filepath, "r")
+    if not file then
+        vim.notify("Could not open file: " .. filepath, vim.log.levels.ERROR)
+        return nil
+    end
+
+    local content = file:read("*all")
+
+    file:close()
+
+    return content
+end
+
+function M.mapSingleCalled(obj)
+    local res
+    if type(obj) == "table" then
+        -- Assuming obj is a Lua table equivalent of a JSON array.
+        local msg = obj[1]
+        local errObj = #obj > 1 and ", " .. obj[2] or ""
+        res = msg .. errObj
+    else
+        res = obj
+    end
+    -- Replace "\\n" with Lua's line separator and Unicode space.
+    res = tostring(res):gsub("\\n", "\n"):gsub('\226\128\131', ' ')
+    return res
+end
+
+function M.stringedCalledAndValue(obj)
+    local valueArray = {}
+    for _, str in ipairs(obj["value"]) do
+        table.insert(valueArray, str)
+    end
+    local valueString = table.concat(valueArray, ", ")
+
+    local calledArray = {}
+    for _, calledItem in ipairs(obj["called"]) do
+        table.insert(calledArray, M.mapSingleCalled(calledItem))
+    end
+    local calledString = table.concat(calledArray, ", ")
+    local stringedValue = valueString:gsub('\226\128\131', ' ')
+
+    return calledString, stringedValue
+end
+
+local function is_number_in_table(tbl, num)
+    for _, value in ipairs(tbl) do
+        if value == tonumber(num) then
+            return true
+        end
+    end
+    return false
+end
+
+function M.find_lines_with_comment_suffix()
+    local bufnr = vim.api.nvim_get_current_buf()
+    local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+    local matching_lines = {}
+    for index, line in ipairs(lines) do
+        if line:match("//%?$") then
+            table.insert(matching_lines, index)
+        end
+    end
+
+    return matching_lines
+end
+
+local function get_plugin_directory()
+    local source = debug.getinfo(1, "S").source
+    local file_path = source:sub(2)                             -- Remove the '@' prefix
+    local plugin_root = vim.fn.fnamemodify(file_path, ":h:h:h") -- Go up three levels: utils.lua -> tsw -> lua -> plugin_root
+    return plugin_root
+end
+
+-- Function to check if a value is in a list (table)
+local function value_in_list(value, list)
+    for _, v in ipairs(list) do
+        if v == value then
+            return true
+        end
+    end
+    return false
+end
+
+local function is_rt_valid(rt)
+    return value_in_list(rt, { "node", "deno", "bun" })
+end
+
+local function is_installed(exec)
+    return vim.fn.executable(exec) == 1
+end
+
+function M.createInlays(data, namespace, showVariables, singleLines)
+    local diagnostics = {}
+
+    for line, value in pairs(data) do
+        local curLine = tonumber(line) - 1
+
+        local obj = value
+        local type = obj["type"]
+
+        local isVariable = (type == "variable")
+        local showVariable = isVariable and showVariables
+        local shouldShowLine = (next(singleLines) == nil or is_number_in_table(singleLines, line))
+        if shouldShowLine and (showVariable or not isVariable) then
+            local calledArray, stringedValue = M.stringedCalledAndValue(obj)
+
+            table.insert(diagnostics, {
+                lnum = curLine, -- Line number (0-indexed)
+                col = #line,    -- Column number (end of line)
+                message = stringedValue,
+                severity = config.severity,
+                source = "tsw",
+                namespace = namespace,
+                type = "ts-worksheet-" .. type
+            })
+        end
+    end
+    return diagnostics
+end
+
+function M.add_inlay_hints(rt, showVariables, showOrder)
+    if is_rt_valid(rt) == false then
+        vim.notify("Only the runtimes 'node', 'bun' or 'deno' are allowed as 'rt' parameter", vim.log.levels.ERROR)
+        return
+    end
+
+    local bufnr = vim.api.nvim_get_current_buf()
+
+    local singleLines = M.find_lines_with_comment_suffix()
+    local file_path = M.get_current_file_path()
+    local file_dir = M.get_directory_from_path(file_path)
+
+    vim.diagnostic.reset(config.namespace, bufnr)
+
+    local mappedRt = rt
+
+    if mappedRt == "node" then
+        mappedRt = "tsx"
+    end
+    if mappedRt == "tsx" and not is_installed(mappedRt) then
+        vim.notify("TSX is being installed")
+        os.execute("npm i -g tsx@4.7.0 > /dev/null 2>&1")
+        vim.notify("TSX is installed")
+    end
+    if not is_installed(mappedRt) then
+        vim.notify(mappedRt .. " is not available in the systems PATH. Please install it.")
+        return
+    end
+    local plugin_dir = get_plugin_directory()
+    local envs = "CLI=" .. mappedRt .. " FILE=" .. file_path
+    if showOrder then
+        envs = envs .. " SHOW_ORDER=true"
+    end
+    local command = envs .. " node " .. plugin_dir .. separator .. "ts-worksheet-cli.js > /dev/null 2>&1"
+    local json_file_path = file_dir .. separator .. ".ws.data.json"
+
+    local r = os.execute(command)
+    if not (r == 0) then
+        vim.notify(
+            "An error occurred running ts-worksheet. Please file an issue if you think this should have worked properly",
+            vim.log.levels.ERROR)
+        return
+    end
+    local file_content = read_file_to_string(json_file_path)
+    os.remove(json_file_path)
+
+    local response = vim.json.decode(file_content)
+    local data = response.data
+    local error = response.error
+
+    if error then
+        if error.message then
+            vim.notify(
+                "An error occurred. Maybe your TypeScript file is not valid? Otherwise file an issue: " .. error.message,
+                vim.log.levels.ERROR)
+        end
+        return
+    end
+
+    if data == nil then
+        vim.notify("There was an error getting the data from the CLI. Please file an issue", vim.log.levels.ERROR)
+        return
+    end
+
+    local diagnostics = M.createInlays(data, config.namespace, showVariables, singleLines)
+
+    vim.diagnostic.set(config.namespace, bufnr, diagnostics, {
+        signs = false,
+        virtual_text = true,
+    })
+
+    vim.notify("Done running with ts-worksheet with " .. rt, vim.log.levels.INFO)
+end
+
+return M
+

--- a/plugin/tsw.lua
+++ b/plugin/tsw.lua
@@ -1,0 +1,7 @@
+if vim.g.loaded_tsw then
+  return
+end
+vim.g.loaded_tsw = true
+
+require('tsw').setup({})
+


### PR DESCRIPTION
Thank you for your fantastic plugin! I came across your video on YouTube and decided to add the possibility of installing your plugin via LazyVim. While the original installation method remains available, I find it more convenient to manage plugins through a centralized manager like LazyVim. I've also included help documentation accessible within Vim via :h tsw.

To maintain backward compatibility, I've copied most of the content from ts-worksheet.lua to utils.lua. This ensures that everything continues to work seamlessly with the new installation method. 

Please let me know if there's anything else you'd like me to adjust or improve!

## Changes

- Reorganized the codebase into a proper Neovim plugin structure
- Split functionality into separate Lua modules:
  - `commands.lua`: Handles user commands and autocommands
  - `config.lua`: Manages plugin configuration
  - `init.lua`: Main entry point for the plugin
  - `utils.lua`: Contains utility functions and core logic
- Copied core logic from `ts-worksheet.lua` to `utils.lua`
- Added plugin doc file `:h tsw` 

## Rationale

1. **Maintainability**: The code is now split into modules, making it easier to maintain and extend in the future.
  
2. **Organization**: Each module handles a specific task, making the codebase more organized and understandable.

3. **Configuration**: The new structure simplifies configuration management with the `config.lua` file.

4. **User Experience**: 
   - Added user commands and autocommands in `commands.lua` for better Neovim integration.
   - Help documentation is accessible with `:h tsw`.

5. **Familiarity**: The structure now follows standard Neovim plugin conventions, making it more user and contributor-friendly.